### PR TITLE
[ADDED] FP16 subfolder check

### DIFF
--- a/model_setup.py
+++ b/model_setup.py
@@ -236,6 +236,7 @@ while True:
 
     if choice=="12":
         dl_all()
+        print("Complete downloaing all models. Exiting SD-1.5 Model setup.........")
         break
     
     if choice=="0":

--- a/model_setup.py
+++ b/model_setup.py
@@ -74,6 +74,9 @@ def download_quantized_models(repo_id, model_fp16, model_int8):
             #print("download_folder", download_folder)
 
         FP16_model = os.path.join(download_folder, "FP16")
+        # on some systems, the FP16 subfolder is not created resulting in a installation crash 
+        if not os.path.isdir(FP16_model):
+            os.mkdir(FP16_model)
         shutil.copytree(download_folder, SD_path_FP16, ignore=shutil.ignore_patterns('FP16', 'INT8'))  
         shutil.copytree(FP16_model, SD_path_FP16, dirs_exist_ok=True)        
 


### PR DESCRIPTION
On some systems, during the installation of the SD-1.5 Controlnet-ReferenceOnly model, the FP16 folder is not always created, resulting in an early exit. Added a simple fix to make sure that folder is created; if not, it will create the path that can continue with installation. 

Example error output
```
Traceback (most recent call last):████████████████████████████████████████████████| 1.72G/1.72G [01:03<00:00, 82.3MB/s]
  File "C:\Users\Local_Admin\GIMP\openvino-ai-plugins-gimp\model_setup.py", line 235, in <module>00:05<01:11, 22.7MB/s]
    dl_all()ce_write.bin: 100%|███████████████████████████████████████████████████| 1.72G/1.72G [00:48<00:00, 37.5MB/s]
  File "C:\Users\Local_Admin\GIMP\openvino-ai-plugins-gimp\model_setup.py", line 206, in dl_all
    dl_sd_15_Referenceonly()
  File "C:\Users\Local_Admin\GIMP\openvino-ai-plugins-gimp\model_setup.py", line 195, in dl_sd_15_Referenceonly
    download_quantized_models(repo_id, model_fp16, model_int8)
  File "C:\Users\Local_Admin\GIMP\openvino-ai-plugins-gimp\model_setup.py", line 78, in download_quantized_models
    shutil.copytree(FP16_model, SD_path_FP16, dirs_exist_ok=True)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Local_Admin\AppData\Local\Programs\Python\Python311\Lib\shutil.py", line 571, in copytree
    with os.scandir(src) as itr:
         ^^^^^^^^^^^^^^^
FileNotFoundError: [WinError 3] The system cannot find the path specified: 'C:\\Users\\Local_Admin\\.cache\\huggingface\\hub\\models--Intel--sd-reference-only\\snapshots\\7b156d5706518c5a2d2355734c89de8e5e897501\\FP16'
```