### PR TITLE
Fixes the issue of whitespace in the user's name

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -53,8 +53,8 @@ call deactivate
 rem cls
 echo.   
 REM copy to gimp plugin dir
-echo Installing plugin in %appdata%\GIMP\2.99\plug-ins
-for /d %%d in (openvino_utils semseg_ov stable_diffusion_ov superresolution_ov ) do ( robocopy gimpenv3\Lib\site-packages\gimpopenvino\plugins\%%d %appdata%\GIMP\2.99\plug-ins\%%d /mir /NFL /NDL /NJH /NJS /nc /ns /np )
+echo Installing plugin in "%appdata%\GIMP\2.99\plug-ins"
+for /d %%d in (openvino_utils semseg_ov stable_diffusion_ov superresolution_ov ) do ( robocopy "gimpenv3\Lib\site-packages\gimpopenvino\plugins\%%d" "%appdata%\GIMP\2.99\plug-ins\%%d" /mir /NFL /NDL /NJH /NJS /nc /ns /np )
 
 echo *** openvino-ai-plugins-gimp Installed ***
 echo.    


### PR DESCRIPTION
My user's name contains a whitespace character, so this install wouldn't work unless I made the following changes and added quotation marks around the directories because I believe robocopy sees the whitespace as the end of the command.

Not a developer or coder, but I figured this out pretty quickly, make edits if there are unnecessary changes.