### PR TITLE
SD V1.5 load model for GPU updated with GPU_QUEUE_THROTTLE_LOW Flag

### DIFF
--- a/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/stable_diffusion_engine.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/stable_diffusion_engine.py
@@ -174,8 +174,11 @@ class StableDiffusionEngineAdvanced(DiffusionPipeline):
         if "NPU" in device:
             with open(os.path.join(model, f"{model_name}.blob"), "rb") as f:
                 return self.core.import_model(f.read(), device)
-        return self.core.compile_model(os.path.join(model, f"{model_name}.xml"), device)
-    
+        elif "GPU" in device: 
+            return self.core.compile_model(os.path.join(model, f"{model_name}.xml"), device, {'GPU_QUEUE_THROTTLE': 'LOW'})
+        else:
+            return self.core.compile_model(os.path.join(model, f"{model_name}.xml"), device)
+        
     def set_dimensions(self):
         latent_shape = self.unet.input("latent_model_input").shape
         if latent_shape[1] == 4:


### PR DESCRIPTION
changes will save 7W power on Pcore due to reduce thread spin.

![image](https://github.com/user-attachments/assets/2023935c-cd17-4d01-94e5-a66803e31101)

![image](https://github.com/user-attachments/assets/1667ed64-1dcb-441c-964d-a20416e0ed5d)

before changes ETL snapshot:

![image](https://github.com/user-attachments/assets/b809511b-82bc-44c9-bf50-1b40d7245d8f)

After changes ETL snapshot:

![image](https://github.com/user-attachments/assets/c231da96-7c22-42a7-a468-cd1fcc391263)
