### PR TITLE
Fix to detect NPU_3700 and disallow compilation

### DIFF
--- a/gimpopenvino/plugins/openvino_utils/tools/model_manager.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/model_manager.py
@@ -320,7 +320,12 @@ def get_npu_architecture(core):
         available_devices = core.get_available_devices()
         if 'NPU' in available_devices:
             architecture = core.get_property('NPU', 'DEVICE_ARCHITECTURE')
-            return NPU_ARCH_3720 if NPU_ARCH_3720 in architecture else NPU_ARCH_4000
+            if NPU_ARCH_3720 in architecture:
+                return NPU_ARCH_3720
+            elif NPU_ARCH_4000 in architecture:
+                return NPU_ARCH_4000
+            return None
+
     except Exception as e:
         logging.error(f"Error retrieving NPU architecture: {str(e)}")
         return None


### PR DESCRIPTION
Testing on RPL w/ dKMB was causing issues with model download. This resolves that issue, as models are not supported on dKMB. 