### PR TITLE
Set config and model paths dynamically from environment vars

### DIFF
--- a/gimpopenvino/complete_install.py
+++ b/gimpopenvino/complete_install.py
@@ -62,7 +62,11 @@ def setup_python_weights(install_location=None, repo_weights_dir=None):
         "weight_path" : weight_path,
         "supported_devices": supported_devices
         }
-    govconfig = os.path.join(plugin_loc, "plugins","openvino_utils", "tools", "gimp_openvino_config.json")    
+    govconfig = (
+        os.path.join(os.environ.get("GIMP_OPENVINO_CONFIG_PATH"), "gimp_openvino_config.json")
+        if os.environ.get("GIMP_OPENVINO_CONFIG_PATH") is not None
+        else os.path.join(plugin_loc, "plugins","openvino_utils", "tools", "gimp_openvino_config.json")
+    )
     with open(govconfig, "w+") as file:
         json.dump(py_dict,file)
 

--- a/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_cannyedge_advanced.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_cannyedge_advanced.py
@@ -586,7 +586,11 @@ class ControlNetCannyEdgeAdvanced(DiffusionPipeline):
 
 
 if __name__ == "__main__":
-    weight_path = os.path.join(os.path.expanduser('~'), "openvino-ai-plugins-gimp", "weights")
+    weight_path = (
+        os.path.join(os.environ.get("GIMP_OPENVINO_MODELS_PATH"), "weights")
+        if os.environ.get("GIMP_OPENVINO_MODELS_PATH") is not None
+        else os.path.join(os.path.expanduser("~"), "openvino-ai-plugins-gimp", "weights")
+    )
     
     model_path = os.path.join(weight_path, "stable-diffusion-ov", "controlnet-canny-advanced")  #os.path.join(weight_path, "stable-diffusion-ov/controlnet-openpose")  -- "D:\\git\\openvino_notebooks\\notebooks\\235-controlnet-stable-diffusion"
     device_name = ["GPU", "GPU" , "GPU","GPU"]

--- a/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_openpose.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_openpose.py
@@ -503,7 +503,11 @@ class ControlNetOpenPose(DiffusionPipeline):
 
 
 if __name__ == "__main__":
-    weight_path = os.path.join(os.path.expanduser('~'), "openvino-ai-plugins-gimp", "weights")
+    weight_path = (
+        os.path.join(os.environ.get("GIMP_OPENVINO_MODELS_PATH"), "weights")
+        if os.environ.get("GIMP_OPENVINO_MODELS_PATH") is not None
+        else os.path.join(os.path.expanduser("~"), "openvino-ai-plugins-gimp", "weights")
+    )
     
     model_path = os.path.join(weight_path, "stable-diffusion-ov/controlnet-openpose")  
     device_name = ["GPU.1", "GPU.1" , "GPU.1"]

--- a/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_openpose_advanced.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_openpose_advanced.py
@@ -638,7 +638,11 @@ class ControlNetOpenPoseAdvanced(DiffusionPipeline):
 
 
 if __name__ == "__main__":
-    weight_path = os.path.join(os.path.expanduser('~'), "openvino-ai-plugins-gimp", "weights")
+    weight_path = (
+        os.path.join(os.environ.get("GIMP_OPENVINO_MODELS_PATH"), "weights")
+        if os.environ.get("GIMP_OPENVINO_MODELS_PATH") is not None
+        else os.path.join(os.path.expanduser("~"), "openvino-ai-plugins-gimp", "weights")
+    )
     
     model_path = os.path.join(weight_path, "stable-diffusion-ov/controlnet-openpose")  #os.path.join(weight_path, "stable-diffusion-ov/controlnet-openpose")  -- "D:\\git\\openvino_notebooks\\notebooks\\235-controlnet-stable-diffusion"
     device_name = ["GPU.1", "GPU.1" , "GPU.1"]

--- a/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_scribble.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_scribble.py
@@ -984,7 +984,11 @@ class ControlNetScribbleAdvanced(DiffusionPipeline):
 
 
 if __name__ == "__main__":
-    weight_path = os.path.join(os.path.expanduser('~'), "openvino-ai-plugins-gimp", "weights")
+    weight_path = (
+        os.path.join(os.environ.get("GIMP_OPENVINO_MODELS_PATH"), "weights")
+        if os.environ.get("GIMP_OPENVINO_MODELS_PATH") is not None
+        else os.path.join(os.path.expanduser("~"), "openvino-ai-plugins-gimp", "weights")
+    )
     
     model_path = os.path.join(weight_path, "stable-diffusion-ov/controlnet-scribble")
     device_name = ["GPU.1", "GPU.1" , "GPU.1"]

--- a/gimpopenvino/plugins/semseg_ov/semseg_ov.py
+++ b/gimpopenvino/plugins/semseg_ov/semseg_ov.py
@@ -149,8 +149,12 @@ def run(procedure, run_mode, image, n_drawables, layer, args, data):
 
     if run_mode == Gimp.RunMode.INTERACTIVE:
         # Get all paths
-        config_path = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)), "..", "openvino_utils", "tools"
+        config_path = (
+            os.environ.get("GIMP_OPENVINO_CONFIG_PATH")
+            if os.environ.get("GIMP_OPENVINO_CONFIG_PATH") is not None
+            else os.path.join(
+                os.path.dirname(os.path.realpath(__file__)), "..", "openvino_utils", "tools"
+            )
         )
         with open(os.path.join(config_path, "gimp_openvino_config.json"), "r") as file:
             config_path_output = json.load(file)

--- a/gimpopenvino/plugins/stable_diffusion_ov/stable_diffusion_ov.py
+++ b/gimpopenvino/plugins/stable_diffusion_ov/stable_diffusion_ov.py
@@ -322,8 +322,12 @@ def on_toggled(widget, dialog):
 def run(procedure, run_mode, image, n_drawables, layer, args, data):
     if run_mode == Gimp.RunMode.INTERACTIVE:
         # Get all paths
-        config_path = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)), "..", "openvino_utils", "tools"
+        config_path = (
+            os.environ.get("GIMP_OPENVINO_CONFIG_PATH")
+            if os.environ.get("GIMP_OPENVINO_CONFIG_PATH") is not None
+            else os.path.join(
+                os.path.dirname(os.path.realpath(__file__)), "..", "openvino_utils", "tools"
+            )
         )
 
         with open(os.path.join(config_path, "gimp_openvino_config.json"), "r") as file:

--- a/gimpopenvino/plugins/superresolution_ov/superresolution_ov.py
+++ b/gimpopenvino/plugins/superresolution_ov/superresolution_ov.py
@@ -170,8 +170,12 @@ def run(procedure, run_mode, image, n_drawables, layer, args, data):
     model_name = args.index(2)
 
     if run_mode == Gimp.RunMode.INTERACTIVE:
-        config_path = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)), "..", "openvino_utils", "tools"
+        config_path = (
+            os.environ.get("GIMP_OPENVINO_CONFIG_PATH")
+            if os.environ.get("GIMP_OPENVINO_CONFIG_PATH") is not None
+            else os.path.join(
+                os.path.dirname(os.path.realpath(__file__)), "..", "openvino_utils", "tools"
+            )
         )
 
         with open(os.path.join(config_path, "gimp_openvino_config.json"), "r") as file:

--- a/model_setup.py
+++ b/model_setup.py
@@ -7,7 +7,11 @@ from pathlib import Path
 sys.path.extend([os.path.join(os.path.dirname(os.path.realpath(__file__)), "gimpopenvino", "plugins", "openvino_utils", "tools")])
 from model_manager import ModelManager
 
-base_model_dir = os.path.join(os.path.expanduser("~"), "openvino-ai-plugins-gimp", "weights")
+base_model_dir = (
+    os.path.join(os.environ.get("GIMP_OPENVINO_MODELS_PATH"), "weights")
+    if os.environ.get("GIMP_OPENVINO_MODELS_PATH") is not None
+    else os.path.join(os.path.expanduser("~"), "openvino-ai-plugins-gimp", "weights")
+)
 
 def main():
 


### PR DESCRIPTION
Hello, I'm working on packaging this plugin as a snap for use on Ubuntu (and other Linux distros supporting snaps) and created the following patch to make the installation and runtime more flexible. This is particularly important for containerized packaging formats where hard-coded paths may point to immutable paths inside the container. 

Some notes:

* Without setting the environment variables the behavior will be unchanged as the variables will fall back to their current paths
* I'm not wed to the names of the variables (`GIMP_OPENVINO_CONFIG_PATH` and `GIMP_OPENVINO_MODELS_PATH`) if there is some other standard naming that is preferred
* I did not document this anywhere in case there are hesitations or concerns about officially supporting this feature, but I'm happy to add docs some place if there is interest