### PR TITLE
Moved environment vars to central location

### DIFF
--- a/gimpopenvino/complete_install.py
+++ b/gimpopenvino/complete_install.py
@@ -16,6 +16,8 @@ import subprocess
 import shutil
 from pathlib import Path
 from openvino.runtime import Core
+from gimpopenvino.plugins.openvino_utils.tools.tools_utils import base_model_dir, config_path_dir
+
 
 def install_base_models(base_model_dir, repo_weights_dir):
     for folder in os.scandir(repo_weights_dir):
@@ -37,7 +39,7 @@ def setup_python_weights(install_location=None, repo_weights_dir=None):
     if os.name == "nt":  # windows
         python_string += ".exe"
     python_path = os.path.join(os.path.dirname(sys.executable), python_string)
-    weight_path = os.path.join(install_location, "weights")
+    weight_path = os.path.join(base_model_dir, "weights")
     if not os.path.isdir(weight_path):
         os.mkdir(weight_path)
 
@@ -62,11 +64,8 @@ def setup_python_weights(install_location=None, repo_weights_dir=None):
         "weight_path" : weight_path,
         "supported_devices": supported_devices
         }
-    govconfig = (
-        os.path.join(os.environ.get("GIMP_OPENVINO_CONFIG_PATH"), "gimp_openvino_config.json")
-        if os.environ.get("GIMP_OPENVINO_CONFIG_PATH") is not None
-        else os.path.join(plugin_loc, "plugins","openvino_utils", "tools", "gimp_openvino_config.json")
-    )
+    govconfig = os.path.join(config_path_dir, "gimp_openvino_config.json")
+
     with open(govconfig, "w+") as file:
         json.dump(py_dict,file)
 

--- a/gimpopenvino/plugins/openvino_utils/model_management_window.py
+++ b/gimpopenvino/plugins/openvino_utils/model_management_window.py
@@ -62,7 +62,7 @@ class ModelManagementWindow(Gtk.Window):
         self._host = "127.0.0.1"
         self._port = 65434
         server = "model_management_server.py"
-        server_path = os.path.join(config_path, server)
+        server_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tools", server)
 
         #if it's not running already, start it up!
         if( self.is_server_running() is False ):

--- a/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_cannyedge_advanced.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_cannyedge_advanced.py
@@ -32,7 +32,8 @@ from diffusers import StableDiffusionControlNetPipeline, ControlNetModel
 
 from openvino.runtime import Model, Core
 from collections import namedtuple
-
+from tools_utils import get_weight_path
+    
 
 from typing import Union, List, Optional, Tuple
 
@@ -586,11 +587,7 @@ class ControlNetCannyEdgeAdvanced(DiffusionPipeline):
 
 
 if __name__ == "__main__":
-    weight_path = (
-        os.path.join(os.environ.get("GIMP_OPENVINO_MODELS_PATH"), "weights")
-        if os.environ.get("GIMP_OPENVINO_MODELS_PATH") is not None
-        else os.path.join(os.path.expanduser("~"), "openvino-ai-plugins-gimp", "weights")
-    )
+    weight_path = get_weight_path()
     
     model_path = os.path.join(weight_path, "stable-diffusion-ov", "controlnet-canny-advanced")  #os.path.join(weight_path, "stable-diffusion-ov/controlnet-openpose")  -- "D:\\git\\openvino_notebooks\\notebooks\\235-controlnet-stable-diffusion"
     device_name = ["GPU", "GPU" , "GPU","GPU"]

--- a/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_openpose.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_openpose.py
@@ -33,7 +33,8 @@ from diffusers import StableDiffusionControlNetPipeline, ControlNetModel
 
 from openvino.runtime import Model, Core
 from collections import namedtuple
-
+from tools_utils import get_weight_path
+    
 from controlnet_aux import OpenposeDetector
 from typing import Union, List, Optional, Tuple
 
@@ -503,11 +504,7 @@ class ControlNetOpenPose(DiffusionPipeline):
 
 
 if __name__ == "__main__":
-    weight_path = (
-        os.path.join(os.environ.get("GIMP_OPENVINO_MODELS_PATH"), "weights")
-        if os.environ.get("GIMP_OPENVINO_MODELS_PATH") is not None
-        else os.path.join(os.path.expanduser("~"), "openvino-ai-plugins-gimp", "weights")
-    )
+    weight_path = get_weight_path()
     
     model_path = os.path.join(weight_path, "stable-diffusion-ov/controlnet-openpose")  
     device_name = ["GPU.1", "GPU.1" , "GPU.1"]

--- a/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_openpose_advanced.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/openvino_common/models_ov/controlnet_openpose_advanced.py
@@ -32,7 +32,8 @@ from diffusers import StableDiffusionControlNetPipeline, ControlNetModel
 
 from openvino.runtime import Model, Core
 from collections import namedtuple
-
+from tools_utils import get_weight_path
+    
 from controlnet_aux import OpenposeDetector
 from typing import Union, List, Optional, Tuple
 
@@ -638,12 +639,7 @@ class ControlNetOpenPoseAdvanced(DiffusionPipeline):
 
 
 if __name__ == "__main__":
-    weight_path = (
-        os.path.join(os.environ.get("GIMP_OPENVINO_MODELS_PATH"), "weights")
-        if os.environ.get("GIMP_OPENVINO_MODELS_PATH") is not None
-        else os.path.join(os.path.expanduser("~"), "openvino-ai-plugins-gimp", "weights")
-    )
-    
+    weight_path = get_weight_path()    
     model_path = os.path.join(weight_path, "stable-diffusion-ov/controlnet-openpose")  #os.path.join(weight_path, "stable-diffusion-ov/controlnet-openpose")  -- "D:\\git\\openvino_notebooks\\notebooks\\235-controlnet-stable-diffusion"
     device_name = ["GPU.1", "GPU.1" , "GPU.1"]
     

--- a/gimpopenvino/plugins/openvino_utils/tools/openvino_common/superes_run_ov.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/openvino_common/superes_run_ov.py
@@ -60,7 +60,7 @@ def run(image, model_path, device, model_name):
 
         core = ov.Core()
         if "esrgan" in model_name and "gpu" not in device.lower():
-            core.set_property({'CACHE_DIR': os.path.join(model_path, '..', 'cache')})
+            core.set_property({'CACHE_DIR': os.path.join(os.path.dirname(model_path), 'cache')})
         
         model = core.read_model(model=model_path)
 

--- a/gimpopenvino/plugins/openvino_utils/tools/tools_utils.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/tools_utils.py
@@ -13,7 +13,7 @@ base_model_dir = (
 config_path_dir = (
     os.path.join(os.environ.get("GIMP_OPENVINO_CONFIG_PATH"))
     if os.environ.get("GIMP_OPENVINO_CONFIG_PATH") is not None
-    else os.path.join(os.path.dirname(gimpopenvino.__file__), "plugins","openvino_utils", "tools") 
+    else os.path.join(os.path.dirname(__file__)) 
 )
 
 def get_weight_path():

--- a/gimpopenvino/plugins/openvino_utils/tools/tools_utils.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/tools_utils.py
@@ -4,8 +4,20 @@
 import os
 import json
 
+base_model_dir = (
+    os.path.join(os.environ.get("GIMP_OPENVINO_MODELS_PATH"))
+    if os.environ.get("GIMP_OPENVINO_MODELS_PATH") is not None
+    else os.path.join(os.path.expanduser("~"), "openvino-ai-plugins-gimp")
+)
+
+config_path_dir = (
+    os.path.join(os.environ.get("GIMP_OPENVINO_CONFIG_PATH"))
+    if os.environ.get("GIMP_OPENVINO_CONFIG_PATH") is not None
+    else os.path.join(os.path.dirname(gimpopenvino.__file__), "plugins","openvino_utils", "tools") 
+)
+
 def get_weight_path():
-    config_path = os.path.dirname(os.path.realpath(__file__))
+    config_path = config_path_dir
     #data={}
     with open(os.path.join(config_path, "gimp_openvino_config.json"), "r") as file:
         data = json.load(file)

--- a/gimpopenvino/plugins/semseg_ov/semseg_ov.py
+++ b/gimpopenvino/plugins/semseg_ov/semseg_ov.py
@@ -19,6 +19,7 @@ import os
 import sys
 sys.path.extend([os.path.join(os.path.dirname(os.path.realpath(__file__)), "..","openvino_utils")])
 from plugin_utils import *
+from tools.tools_utils import base_model_dir, config_path_dir
 
 _ = gettext.gettext
 image_paths = {
@@ -149,18 +150,17 @@ def run(procedure, run_mode, image, n_drawables, layer, args, data):
 
     if run_mode == Gimp.RunMode.INTERACTIVE:
         # Get all paths
-        config_path = (
-            os.environ.get("GIMP_OPENVINO_CONFIG_PATH")
-            if os.environ.get("GIMP_OPENVINO_CONFIG_PATH") is not None
-            else os.path.join(
-                os.path.dirname(os.path.realpath(__file__)), "..", "openvino_utils", "tools"
-            )
-        )
-        with open(os.path.join(config_path, "gimp_openvino_config.json"), "r") as file:
+        with open(os.path.join(config_path_dir, "gimp_openvino_config.json"), "r") as file:
             config_path_output = json.load(file)
         
         python_path = config_path_output["python_path"]
-        config_path_output["plugin_path"] = os.path.join(config_path, "semseg_ov.py")
+    
+        config_path_output["plugin_path"] = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), 
+            "..", 
+            "openvino_utils", 
+            "tools",  
+            "semseg_ov.py")
         
         device_name_enum = DeviceEnum(config_path_output["supported_devices"])
 

--- a/gimpopenvino/plugins/stable_diffusion_ov/stable_diffusion_ov.py
+++ b/gimpopenvino/plugins/stable_diffusion_ov/stable_diffusion_ov.py
@@ -31,6 +31,7 @@ PORT = 65432  # The port used by the server
 sys.path.extend([os.path.join(os.path.dirname(os.path.realpath(__file__)), "..","openvino_utils")])
 from plugin_utils import *
 from model_management_window import ModelManagementWindow
+from tools.tools_utils import base_model_dir, config_path_dir
 
 _ = gettext.gettext
 image_paths = {
@@ -322,21 +323,18 @@ def on_toggled(widget, dialog):
 def run(procedure, run_mode, image, n_drawables, layer, args, data):
     if run_mode == Gimp.RunMode.INTERACTIVE:
         # Get all paths
-        config_path = (
-            os.environ.get("GIMP_OPENVINO_CONFIG_PATH")
-            if os.environ.get("GIMP_OPENVINO_CONFIG_PATH") is not None
-            else os.path.join(
-                os.path.dirname(os.path.realpath(__file__)), "..", "openvino_utils", "tools"
-            )
-        )
-
-        with open(os.path.join(config_path, "gimp_openvino_config.json"), "r") as file:
+        with open(os.path.join(config_path_dir, "gimp_openvino_config.json"), "r") as file:
             config_path_output = json.load(file)
 
         python_path = config_path_output["python_path"]
         client = "test-client.py"
-        config_path_output["plugin_path"] = os.path.join(config_path, client)
-
+        config_path_output["plugin_path"] = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), 
+            "..", 
+            "openvino_utils", 
+            "tools", 
+            client)
+        
         supported_devices = []
         for device in config_path_output["supported_devices"]:
            if 'GNA' not in device:
@@ -824,7 +822,7 @@ def run(procedure, run_mode, image, n_drawables, layer, args, data):
             # trigger a call to this, as it includes some important logic.
             model_sensitive_combo_changed(model_combo)
 
-        model_management_window = ModelManagementWindow(config_path, python_path, populate_model_combo)
+        model_management_window = ModelManagementWindow(config_path_dir, python_path, populate_model_combo)
 
         installed_models = model_management_window.get_installed_model_list()
 
@@ -923,7 +921,12 @@ def run(procedure, run_mode, image, n_drawables, layer, args, data):
                         device_power_mode = "Best performance"
 
                 server = "stable_diffusion_ov_server.py"
-                server_path = os.path.join(config_path, server)
+                server_path = os.path.join(
+                    os.path.dirname(os.path.realpath(__file__)), 
+                    "..",
+                    "openvino_utils",
+                    "tools", 
+                    server)
 
                 run_load_model_thread = threading.Thread(target=async_load_models, args=(python_path, server_path, model_name, str(supported_devices), device_power_mode,dialog))
                 run_load_model_thread.start()

--- a/gimpopenvino/plugins/superresolution_ov/superresolution_ov.py
+++ b/gimpopenvino/plugins/superresolution_ov/superresolution_ov.py
@@ -21,6 +21,8 @@ gi.require_version("Gtk", "3.0")
 
 _ = gettext.gettext
 
+from tools.tools_utils import base_model_dir, config_path_dir
+
 image_paths = {
     "logo": os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "..", "openvino_utils", "images", "plugin_logo.png"
@@ -170,19 +172,16 @@ def run(procedure, run_mode, image, n_drawables, layer, args, data):
     model_name = args.index(2)
 
     if run_mode == Gimp.RunMode.INTERACTIVE:
-        config_path = (
-            os.environ.get("GIMP_OPENVINO_CONFIG_PATH")
-            if os.environ.get("GIMP_OPENVINO_CONFIG_PATH") is not None
-            else os.path.join(
-                os.path.dirname(os.path.realpath(__file__)), "..", "openvino_utils", "tools"
-            )
-        )
-
-        with open(os.path.join(config_path, "gimp_openvino_config.json"), "r") as file:
+        with open(os.path.join(config_path_dir, "gimp_openvino_config.json"), "r") as file:
             config_path_output = json.load(file)
         
         python_path = config_path_output["python_path"]
-        config_path_output["plugin_path"] = os.path.join(config_path, "superresolution_ov.py")
+        config_path_output["plugin_path"] = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), 
+            "..", 
+            "openvino_utils", 
+            "tools", 
+            "superresolution_ov.py")
         
         device_name_enum = DeviceEnum(config_path_output["supported_devices"])
 

--- a/model_setup.py
+++ b/model_setup.py
@@ -7,16 +7,11 @@ from pathlib import Path
 sys.path.extend([os.path.join(os.path.dirname(os.path.realpath(__file__)), "gimpopenvino", "plugins", "openvino_utils", "tools")])
 from model_manager import ModelManager
 
-base_model_dir = (
-    os.path.join(os.environ.get("GIMP_OPENVINO_MODELS_PATH"), "weights")
-    if os.environ.get("GIMP_OPENVINO_MODELS_PATH") is not None
-    else os.path.join(os.path.expanduser("~"), "openvino-ai-plugins-gimp", "weights")
-)
+from gimpopenvino.complete_install import base_model_dir
 
 def main():
-
     try:
-        weight_path = base_model_dir
+        weight_path = os.path.join(base_model_dir,"weights")
 
         #Move to a temporary working directory in a known place.
         # This is where we'll be downloading stuff to, etc.


### PR DESCRIPTION
Moved env vars to a central place to make maintenance easier. 
Tested this PR on Linux (Ubuntu 24.04, Intel Core Ultra) and Windows (Intel Core Ultra Series 2) 