### PR TITLE
Add docs for Linux snap installation

### DIFF
--- a/Docs/linux_install_guide.md
+++ b/Docs/linux_install_guide.md
@@ -1,4 +1,24 @@
-# Build GIMP
+There are two methods for installing the plugins in Linux:
+
+* Install the plugins from the Snap Store
+* Build and install GIMP and the plugins manually
+
+# Snap Installation
+
+ For Linux distributions supporting snaps (e.g. Ubuntu), the plugins can be installed along with the GIMP snap with these commands:
+
+```
+sudo snap install gimp --channel preview/stable
+sudo snap install intel-npu-driver --beta # for NPU support
+sudo snap install openvino-toolkit-2404 --beta
+sudo snap install openvino-ai-plugins-gimp --beta
+```
+
+More details can be found [here](https://github.com/snapcrafters/gimp/tree/preview?tab=readme-ov-file#openvino-ai-plugins).
+
+# Building and installing the plugins manually
+
+## Build GIMP
 1. Create a directory where you will download and build all of the sources for GIMP
     ```sh
     cd $HOME
@@ -43,7 +63,7 @@
     sudo ninja -C _build install
     cd ..
     ```
-# Install Plugins
+## Install Plugins
 1. Clone this repo
    ```sh
    cd $HOME/GIMP
@@ -56,7 +76,7 @@
    ./openvino-ai-plugins-gimp/install.sh
    ```
 
-# Verify Installation
+## Verify Installation
  Start GIMP, ensuring to setup the environment variables correctly,  and you should see 'OpenVINO-AI-Plugins' show up in 'Layer' menu
    ```sh
    export GI_TYPELIB_PATH=/usr/lib/x86_64-linux-gnu/girepository-1.0:/usr/local/lib/x86_64-linux-gnu/girepository-1.0


### PR DESCRIPTION
This PR adds docs to the Linux installation docs to outline the steps for installing GIMP and the plugins from the Snap Store. We recently wrapped up publishing these plugins to the Snap Store and blogged about it [here](https://discourse.ubuntu.com/t/canonical-brings-genai-to-gimp-3-0-with-intel-openvino-ai-plugins/54799).

One cool thing about the snaps is that NPU and GPU support is built in, so a user does not need to install all the compute runtime, OpenCL, or NPU driver bits on their host machine. Those will all comes from the snaps and work across a number of different CPUs (meteor lake, lunar lake, arrow lake) and GPUs (DG2 and BMG) that I've tested.

Some other notes for future work:

* We hope to continue tracking new releases in this repo and updating the snap accordingly
* Alternatively, if you are interested in migrating the snap packaging into this repo and co-maintaining it, that would also be great. We recently worked with some folks from the OpenVINO team at Intel to set up an [OpenVINO publisher](https://snapcraft.io/publisher/openvino) in the Snap Store. You could be made collaborators so you can contribute to new releases if you are interested. :)



