### PR TITLE
Rely on optimum-cli to be on PATH

### DIFF
--- a/gimpopenvino/plugins/openvino_utils/tools/model_manager.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/model_manager.py
@@ -857,7 +857,7 @@ class ModelManager:
                         #print("optimun-cli full install path",full_install_path)
                         import subprocess
                         
-                        optimum_ex = sys.executable.replace("python", "optimum-cli").replace("optimum-cli3", "optimum-cli")
+                        optimum_ex = "optimum-cli"
 
                         output_file = Path(os.path.join(full_install_path, "export_output.log"))
                         if(model_id != "sd_15_inpainting"):


### PR DESCRIPTION
Hello! I'm working on updating the snap to v3.1.2 and this line is a bit problematic because it assumes `optimum-cli` will be in the same directory as the python executable (which is not the case in the snap). 

I haven't tested this in other environments - only the snap - so it's possible I haven't accounted for something.  Are there cases where you expect `optimum-cli` will not be on the system's search path (e.g. `PATH` in Linux)? 

