### PR TITLE
Update OpenVINO to 2026.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ For detailed steps and tips please refer to [Linux Installation Guide](./Docs/li
 4. By default the opened image in canvas will be used as initial image to the model. You can also select a different image by browsing from files.
 5. Click on “Generate”. Wait for the total inference steps to get completed.
 
-#### C. Stable-Diffusion-1.5 Inpainting - Make sure to download and convert the model during install process.
+#### C. Stable-Diffusion-1.5 / SDXL Inpainting - Make sure to download and convert the model during install process.
 1. Choose a layer or Open an image of size 512x512. (Currently works best with this resolution)
 2. Use "Free select tool" to select the area in your image that you wish to change.
 3. Right click on your image and click on "Add layer mask". Then choose "Selection" in "Initialize layer Mask to". This should create a mask with your selection.
-4. Follow steps 2,3,4,5 from section A. Please note that you will only see "sd_1.5_Inpainting" in model options if you added a mask layer to your image.
+4. Follow steps 2,3,4,5 from section A. Please note that you will only see the inpainting models in the drop down menu, if you added a mask layer to your image.
 5. Click on “Generate”. Wait for the total inference steps to get completed.
 
 #### D. Stable-Diffusion-1.5 Controlnet-Openpose - Make sure to download and convert the model during install process.
@@ -123,7 +123,6 @@ The very first time you do "Load Models", it may take a few minutes. Subsequent 
 
 FastSD is a faster version of stable diffusion based on Latent Consistency Models and Adversarial Diffusion Distillation. It Supports CPU/GPU/NPU faster inference using OpenVINO.
 - FastSD models can be edited by using the FastSD Model Manager
-- FLUX.1-schnell (3 to 4 steps),SANA sprint model (2 steps) support
 - ⚠️ Models are downloaded at runtime, the first time the model is used, hence the initial generation may take some time. Subsequent image generation will be more performant.
 
 Note: For NPU usage please use the `rupeshs/sd15-lcm-square-openvino-int8` model.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For detailed steps and tips please refer to [Linux Installation Guide](./Docs/li
 1. Choose a layer or Open an image of size 512x512. (Currently works best with this resolution)
 2. Use "Free select tool" to select the area in your image that you wish to change.
 3. Right click on your image and click on "Add layer mask". Then choose "Selection" in "Initialize layer Mask to". This should create a mask with your selection.
-4. Follow steps 2,3,4,5 from section A. Please note that you will only see the inpainting models in the drop down menu, if you added a mask layer to your image.
+4. Follow steps 2,3,4,5 from section A. Please note that you will only see the inpainting models in the drop-down menu if you added a mask layer to your image.
 5. Click on “Generate”. Wait for the total inference steps to get completed.
 
 #### D. Stable-Diffusion-1.5 Controlnet-Openpose - Make sure to download and convert the model during install process.

--- a/gimpopenvino/__init__.py
+++ b/gimpopenvino/__init__.py
@@ -1,0 +1,9 @@
+import warnings
+
+# Suppress mediapipe warning from controlnet_aux when it's not installed
+# mediapipe is an optional dependency for controlnet_aux but not used in our pipeline
+warnings.filterwarnings(
+    "ignore",
+    message=".*The module 'mediapipe' is not installed.*",
+    category=UserWarning
+)

--- a/gimpopenvino/plugins/openvino_utils/tools/model_manager.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/model_manager.py
@@ -411,14 +411,20 @@ def get_npu_config(core, architecture):
         return None
     
 class ModelManager:
-    def __init__(self, weight_path):
+    def __init__(self, weight_path, npu_arch=None, npu_is_available=None):
         self._core = ov.Core()
-        self._npu_arch = get_npu_architecture(self._core)
+        if npu_arch is not None:
+            self._npu_arch = npu_arch
+        else:
+            self._npu_arch = get_npu_architecture(self._core)
         self._npu_config = get_npu_config(self._core, self._npu_arch)
         self._npu_driver_version = get_npu_driver_version(self._core)
         self._weight_path = weight_path
         self._install_location = os.path.join(self._weight_path, "stable-diffusion-ov")
-        self._npu_is_available = True if self._npu_arch is not NPUArchitecture.ARCH_3700 and self._npu_arch is not NPUArchitecture.ARCH_NONE else False
+        if npu_is_available is not None:
+            self._npu_is_available = npu_is_available
+        else:
+            self._npu_is_available = self._npu_arch is not NPUArchitecture.ARCH_3700 and self._npu_arch is not NPUArchitecture.ARCH_NONE
         self.show_hf_download_tqdm = False
 
         self.hf_api = HfApi()

--- a/install.bat
+++ b/install.bat
@@ -40,7 +40,6 @@ call "gimpenv3\Scripts\activate"
 
 REM Install required packages
 pip install wmi
-pip install -r "%~dp0\requirements.txt" | find /V "already satisfied"
 pip install "%~dp0\."
 
 REM post install steps:

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ python3 -m venv gimpenv3
 source gimpenv3/bin/activate
 
 # Upgrade pip and install required packages
-pip3 install -r "$script_dir/requirements.txt" | grep -v "already satisfied"
+pip3 install --upgrade pip
 pip3 install "$script_dir/."
 
 # post installation steps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-openvino==2026.0.0
-openvino-genai==2026.0.0.0
-optimum
-optimum-intel 
-peft
-pydantic
-tomesd
-hf_xet 
-transformers<=4.56.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-openvino==2025.4.0
-openvino-genai==2025.4.0.0
+openvino==2026.0.0
+openvino-genai==2026.0.0.0
 optimum
 optimum-intel 
 peft

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     ],
     keywords="openvino gimp ai plugins",
     packages=find_packages(),
-    python_requires=">=3.7",  # Update Python requirement
+    python_requires=">=3.10",
     include_package_data=True,
     install_requires=[
         "numpy",
@@ -92,13 +92,21 @@ setup(
         "opencv-python>=4.8.1.78",
         "scikit-image",
         "timm==0.4.5",
-        "transformers>=4.37.0",
-        "diffusers",
+        "transformers>=4.37.0,<=4.56.2",
+        "diffusers<=0.37.1",
         "controlnet-aux>=0.0.6",
-        "openvino",
+        "openvino>=2026.2",
+        "openvino-genai>=2026.2",
+        "protobuf",
         "psutil",
         "matplotlib",
-        "sentencepiece"
+        "sentencepiece",
+        "optimum",
+        "optimum-intel",
+        "peft",
+        "pydantic",
+        "tomesd",
+        "hf_xet",
     ],
 )
 


### PR DESCRIPTION
## Summary

Promotes the OpenVINO 2026.x bump and the dependency-consolidation work from `development` to `main`. Three logical changes:

1. **OpenVINO 2026.2 bump** (PR #237 + earlier `1107f42`) — moves runtime to OV 2026.2 and OpenVINO-GenAI 2026.2.
2. **Dependency consolidation** — `requirements.txt` deleted; all runtime deps now live in `setup.py` `install_requires`. `install.sh` / `install.bat` no longer reference `requirements.txt`.
3. **`ModelManager` constructor extension** — `__init__` now accepts optional `npu_arch` and `npu_is_available` kwargs so callers that have already detected NPU state can inject it instead of forcing `ModelManager` to redo the `ov.Core()` queries. Defaults preserve existing behavior.

Plus minor README copy edits and a mediapipe `UserWarning` suppression at package import.

