### PR TITLE
Update Transformers Version and resolve issue with LCM model download

### DIFF
--- a/gimpopenvino/plugins/openvino_utils/tools/model_manager.py
+++ b/gimpopenvino/plugins/openvino_utils/tools/model_manager.py
@@ -220,7 +220,7 @@ g_installable_base_model_map = {
     {
         "name": "Stable Diffusion 1.5 LCM",
         "repo_id": "SimianLuo/LCM_Dreamshaper_v7",
-        "download_exclude_filters": ["*.py", "*.png", "LCM_Dreamshaper_v7_4k.safetensors","model.onnx_data"],
+        "download_exclude_filters": ["*.py", "*.png", "LCM_Dreamshaper_v7_4k.safetensors","*.onnx_data","*.onnx"],
         
     },
 

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         "opencv-python>=4.8.1.78",
         "scikit-image",
         "timm==0.4.5",
-        "transformers>=4.37.0,<=4.56.2",
+        "transformers>=4.51.0,<5.6",
         "diffusers<=0.37.1",
         "controlnet-aux>=0.0.6",
         "openvino>=2026.2",


### PR DESCRIPTION

# Summary
This PR bumps the supported transformers dependency range and corrects the model download exclude filters for the Stable Diffusion 1.5 LCM model.

## Changes
Setup:

- Updated the transformers version constraint from >=4.37.0,<=4.56.2 to >=4.51.0,<5.6.
- Raises the minimum supported version to 4.51.0.
- Widens the upper bound to <5.6 to allow newer transformers releases.

Model Manager:

- Fixed the download_exclude_filters for the Stable Diffusion 1.5 LCM (SimianLuo/LCM_Dreamshaper_v7) model.
- Replaced the literal "model.onnx_data" entry with the wildcard filters ".onnx_data" and ".onnx".
- This ensures all ONNX weight/data files are excluded during download (not just a single hard-coded filename), reducing unnecessary download size.

## Motivation
Broaden transformers compatibility to unblock newer environments while keeping a tested lower bound.
The previous LCM exclude filter only matched one specific ONNX data filename, so other ONNX artifacts were still being downloaded. Using wildcards reliably skips all ONNX files, which aren't needed for the OpenVINO workflow.