### PR TITLE
fix(install_utils): add missing `import logging` so NPU detection can fall back

### DIFF
--- a/gimpopenvino/install_utils.py
+++ b/gimpopenvino/install_utils.py
@@ -11,6 +11,7 @@ import sys
 import json
 import uuid
 import shutil
+import logging
 import platform
 import subprocess
 from pathlib import Path


### PR DESCRIPTION
## Problem

`get_npu_architecture()` in `gimpopenvino/install_utils.py` wraps its OpenVINO queries in `try/except` so that a machine whose NPU cannot answer `DEVICE_ARCHITECTURE` still ends up with a usable `ARCH_NONE`:

```python
    except Exception as e:
        logging.error(f"Error retrieving NPU architecture: {str(e)}")
        return NPUArchitecture.ARCH_NONE
```

But `install_utils.py` never imports `logging`, so the recovery path raises instead of recovering:

```
NameError: name 'logging' is not defined
```

`ModelManager.__init__` calls it with no guard of its own (`gimpopenvino/plugins/openvino_utils/tools/model_manager.py:419`), so instead of degrading to "no usable NPU" the plugin fails to start.

```console
$ python3 -m pyflakes gimpopenvino/install_utils.py
gimpopenvino/install_utils.py:99:9: undefined name 'logging'
```

This is the only `logging.` reference in the file, which is why it survived — the module works fine as long as the NPU query never throws.

## Reproduction

An `ov.Core` stub that reports an NPU and raises on `get_property` — exactly the case the `except` block was written for:

```python
class BadCore:
    def get_available_devices(self):
        return ['CPU', 'GPU', 'NPU']
    def get_property(self, *a, **k):
        raise RuntimeError('Exception from src/inference: NPU property query failed')
```

| | result |
|---|---|
| before | `get_npu_architecture(BadCore())` raised `NameError: name 'logging' is not defined` |
| after | `ERROR:root:Error retrieving NPU architecture: ... NPU property query failed`<br>`get_npu_architecture(BadCore()) -> NPUArchitecture.ARCH_NONE` |

## Fix

One line: `import logging`, placed to keep the existing length-ordered import block intact.

The sibling helpers this function is used alongside — `get_npu_driver_version()` and `get_npu_config()` in `model_manager.py` — log in exactly the same shape, and that module does `import logging` at the top; this file was just missing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
