### PR TITLE
Fix OpenVINO model export and bump transformers past the security-vulnerable range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,8 @@ setup(
         "opencv-python>=4.8.1.78",
         "scikit-image",
         "timm==0.4.5",
-        "transformers>=4.51.0,<5.6",
+        # transformers <5.10 has a security vulnerability; optimum-intel main caps at <5.11.
+        "transformers>=5.10,<5.11",
         "diffusers<=0.37.1",
         "controlnet-aux>=0.0.6",
         "openvino>=2026.2",
@@ -101,8 +102,9 @@ setup(
         "psutil",
         "matplotlib",
         "sentencepiece",
-        "optimum",
-        "optimum-intel",
+        "optimum~=2.3.0",
+        # No PyPI optimum-intel release supports transformers>=5.6 yet; pin main commit.
+        "optimum-intel @ git+https://github.com/huggingface/optimum-intel.git@20390257acb98993f99cdd3bf4df1c983eccadef",
         "peft",
         "pydantic",
         "tomesd",


### PR DESCRIPTION
# Summary
Pins the dependency stack so SDXL/diffusers model conversion via optimum-cli export openvino works reliably, and moves transformers to >=5.10 to pick up a security fix. Previously, unpinned optimum / optimum-intel resolved to an incompatible pair, breaking model export and leaving transformers on a vulnerable version.

## Problem

- With optimum/optimum-intel unpinned, pip resolved a mismatched combination (e.g. optimum 2.3.0 + optimum-intel 1.15.0). Stale command-registration files from the old optimum-intel referenced the removed BaseOptimumCLICommand symbol, causing optimum-cli export openvino to crash with:
`ImportError: cannot import name 'BaseOptimumCLICommand' from 'optimum.commands'`

  The failed export left the model folder empty, which surfaced downstream as a misleading Text2ImagePipeline error: Failed to open ...\model_index.json.
- transformers < 5.10 carries a known security vulnerability. The last PyPI optimum-intel release (2.1.0) caps at transformers < 5.6, making >=5.10 unsatisfiable against a released optimum-intel.

## Changes
- transformers>=4.51.0,<5.6 → transformers>=5.10,<5.11 (security fix; upper bound matches optimum-intel main's <5.11 ceiling).
- optimum (unpinned) → optimum~=2.3.0 (required by optimum-intel main).
- optimum-intel (unpinned) → pinned to a specific optimum-intel main commit (20390257acb98993f99cdd3bf4df1c983eccadef, 2.2.0.dev0), since no PyPI release supports transformers>=5.6 yet. Pinning the exact commit keeps installs reproducible rather than tracking a moving branch.